### PR TITLE
oqs-gnutls: Fix typo in cross_verify rule

### DIFF
--- a/providers/oqs-gnutls/Makefile
+++ b/providers/oqs-gnutls/Makefile
@@ -109,7 +109,7 @@ verify: requirements/verify
 cross_verify: requirements/verify
 	@if [ -f "$(VERIFY_SCRIPT)" ] ; then \
 		echo && echo "[ $(PROVIDER_NAME) ] Cross Verifying Artifacts:" ; \
-		echo > $(VERIFY_LOG) ; \
+		echo > $(VERIFY_LOGFILE) ; \
 		for i in ../* ; do \
 			echo "  -  $$i" ; \
 			result=`cd "$$i" && make verify 2>&1 > "$(VERIFY_LOGFILE)" ` ; \


### PR DESCRIPTION
Fixes: #64 