### PR TITLE
Add new automated verifier using QUBIP-aurora

### DIFF
--- a/.github/workflows/artifact_validation.yaml
+++ b/.github/workflows/artifact_validation.yaml
@@ -61,6 +61,21 @@ jobs:
         with:
           name: Compatibility_openssl36_csv
           path: ./output/
+  qubip_aurora_cert_validation:
+    runs-on: ubuntu-latest
+    container: nisectuni/pq-container:f42-aurora-nt-1783613245
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install prereqs
+        run: dnf -y install zip diff
+      - name: Test artifacts with OpenSSL 3.2 with aurora provider
+        run: ./src/test_certs_r5.sh qubip-aurora
+      - name: Save artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Compatibility_qubip_aurora_csv
+          path: ./output/
   composite_ref_impl_validation:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/artifact_validation.yaml
+++ b/.github/workflows/artifact_validation.yaml
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:latest
     # needs: [bc_validation, openssl_cert_validation, openssl_cms_validation, ssai_validation, composite_ref_impl_validation]
-    needs: [bc_validation, openssl_cert_validation, openssl_cms_validation, composite_ref_impl_validation]
+    needs: [bc_validation, openssl_cert_validation, openssl_cms_validation, composite_ref_impl_validation, qubip_aurora_cert_validation]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -147,6 +147,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Compatibility_openssl_csv
+          path: output/
+      - name: Get QUBIP-aurora results from previous job
+        uses: actions/download-artifact@v4
+        with:
+          name: Compatibility_qubip_aurora_csv
           path: output/
       - name: Get OpenSSL 3.6 results from previous job
         uses: actions/download-artifact@v4

--- a/src/test_certs_r5.sh
+++ b/src/test_certs_r5.sh
@@ -41,6 +41,7 @@ alias_for_openssl() {
 # The outcome depends on openssl version and its configuration: extra providers
 # can add support for algorithm not supported by the OpenSSL `default`
 # provider.
+# Returns 0 on success, 1 on error, 100 for "skip"
 openssl_check_ta() {
     _tafile="$1"
     _oid="$2"
@@ -48,7 +49,7 @@ openssl_check_ta() {
     openssl list --signature-algorithms --kem-algorithms | grep " $oid,"
     if [ $? != 0 ]; then
         printf "\nSkipping %s, unsupported\n" "$_tafile" | tee -a "$logfile"
-        return 1
+        return 100
     fi
 
     # Baseline test whether TA cert is well formed
@@ -100,6 +101,10 @@ test_ta () {
     printf "\nTesting %s\n" $tafile >> $logfile
 
     # The actual command that is the heart of this script
+    # Expected status values:
+    #   0       SUCCESS
+    #   100     SKIPPED
+    #   *       FAIL
     if [ "$verifier" = "ssai" ]; then
         output=$(validator ta --ta-certificate $tafile 2>&1)
         status=$?
@@ -117,12 +122,18 @@ test_ta () {
 
 
     # test for an error and print a link in the results CSV file
-    if [ $status -ne 0 ]; then
-        echo "Certificate Validation Result: FAIL"
-        echo $oid,cert,N >> $resultsfile
-    else
+    # Expected status values:
+    #   0       SUCCESS
+    #   100     SKIPPED
+    #   *       FAIL
+    if [ $status -eq 0 ]; then
         echo "Certificate Validation Result: SUCCESS"
         echo $oid,cert,Y >> $resultsfile
+    elif [ $status -eq 100 ]; then
+        echo "Certificate Validation Result: SKIP"
+    else
+        echo "Certificate Validation Result: FAIL"
+        echo $oid,cert,N >> $resultsfile
     fi
 }
 

--- a/src/test_certs_r5.sh
+++ b/src/test_certs_r5.sh
@@ -6,11 +6,15 @@ if [ $# -lt 1 ]; then
 fi
 
 verifier=$1
-if [ "$verifier" != "bc" ] && [ "$verifier" != "ssai"] && [ "$verifier" != "openssl"]; then
+case "$verifier" in
+  bc|ssai|openssl|qubip-aurora)
+    echo "Running with verifier $verifier." 
+    ;;
+  *)
     echo "ERROR: verifier \"$verifier\" not supported"
-    exit -1
-fi
-echo "Running with verifier $verifier." 
+    exit 255
+    ;;
+esac
 
 certsdir="artifacts_certs_r5"
 certszip="artifacts_certs_r5.zip"
@@ -25,6 +29,13 @@ printf "Build time: %s\n\n" "$(date)" > $logfile
 
 alreadyTestedOIDs=";"
 
+# Return true (0) if this verifier is an alias for the openssl verifier
+alias_for_openssl() {
+  case "$1" in
+    qubip-aurora|openssl) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 # This only tests self-signed TA certs with openssl
 # The outcome depends on openssl version and its configuration: extra providers
@@ -92,7 +103,7 @@ test_ta () {
     if [ "$verifier" = "ssai" ]; then
         output=$(validator ta --ta-certificate $tafile 2>&1)
         status=$?
-    elif [ "$verifier" = "openssl" ]; then
+    elif alias_for_openssl "$verifier"; then
         output=$(openssl_check_ta "$tafile" "$oid" 2>&1)
         status=$?
     else

--- a/src/test_certs_r5.sh
+++ b/src/test_certs_r5.sh
@@ -6,7 +6,7 @@ if [ $# -lt 1 ]; then
 fi
 
 verifier=$1
-if [ "$verifier" != "bc" ] && [ "$verifier" != "ssai"]; then
+if [ "$verifier" != "bc" ] && [ "$verifier" != "ssai"] && [ "$verifier" != "openssl"]; then
     echo "ERROR: verifier \"$verifier\" not supported"
     exit -1
 fi
@@ -24,6 +24,37 @@ mkdir -p $outputdir
 printf "Build time: %s\n\n" "$(date)" > $logfile
 
 alreadyTestedOIDs=";"
+
+
+# This only tests self-signed TA certs with openssl
+# The outcome depends on openssl version and its configuration: extra providers
+# can add support for algorithm not supported by the OpenSSL `default`
+# provider.
+openssl_check_ta() {
+    _tafile="$1"
+    _oid="$2"
+
+    openssl list --signature-algorithms --kem-algorithms | grep " $oid,"
+    if [ $? != 0 ]; then
+        printf "\nSkipping %s, unsupported\n" "$_tafile" | tee -a "$logfile"
+        return 1
+    fi
+
+    # Baseline test whether TA cert is well formed
+    openssl x509 -in "$_tafile" -text -noout
+    if [ $? -ne 0 ]; then
+        echo "ERROR: malformed cert" | tee -a "$logfile"
+        return 1
+    fi
+
+    # Baseline test whether TA cert is self-signed
+    openssl verify -no_check_time -check_ss_sig -CAfile "$_tafile" "$_tafile"
+    if [ $? -ne 0 ]; then
+        echo "ERROR: self-signed signature verification" | tee -a "$logfile"
+        return 1
+    fi
+    return 0
+}
 
 # Requires an input: the TA file to test
 test_ta () {
@@ -60,6 +91,9 @@ test_ta () {
     # The actual command that is the heart of this script
     if [ "$verifier" = "ssai" ]; then
         output=$(validator ta --ta-certificate $tafile 2>&1)
+        status=$?
+    elif [ "$verifier" = "openssl" ]; then
+        output=$(openssl_check_ta "$tafile" "$oid" 2>&1)
         status=$?
     else
         echo "ERROR: verifier \"$verifier\" not supported"


### PR DESCRIPTION
This uses the [aurora provider](https://github.com/QUBIP/aurora) from the [QUBIP project](https://qubip.eu) to add an automated verifier for TAs.

Currently aurora supports only a subset of the composite signatures:
- MLDSA44_Ed25519
- MLDSA65_Ed25519

And pure algorithms:
- MLDSA{44,65,87}
- SLHDSA-SHAKE-{128f,192f,256s}